### PR TITLE
fix(git-tag-name): npm5 has issues with git tags with @ and / chars

### DIFF
--- a/src/tasks/Publish/get-git-tag-name.js
+++ b/src/tasks/Publish/get-git-tag-name.js
@@ -1,4 +1,6 @@
+import { normalisePackageNameNpm } from './normalise-package-name';
+
 export default function getGitTagName(pkg) {
-  const gitpkgPackageName = `${pkg.name}@${pkg.version}-gitpkg`;
+  const gitpkgPackageName = `${normalisePackageNameNpm(pkg.name)}-v${pkg.version}-gitpkg`;
   return gitpkgPackageName;
 }

--- a/src/tasks/Publish/normalise-package-name.js
+++ b/src/tasks/Publish/normalise-package-name.js
@@ -10,10 +10,10 @@ export default async function normalisePackageName(name) {
   return normalisePackageNameYarn(name);
 }
 
-function normalisePackageNameNpm(name) {
+export function normalisePackageNameNpm(name) {
   return name[0] === '@' ? name.substr(1).replace(/\//g, '-') : name;
 }
 
-function normalisePackageNameYarn(name) {
+export function normalisePackageNameYarn(name) {
   return name[0] === '@' ? name.substr(1).replace('/', '-') : name;
 }

--- a/test/tasks/get-git-tag-name.test.js
+++ b/test/tasks/get-git-tag-name.test.js
@@ -1,7 +1,7 @@
 import getGitTagName from '../../src/tasks/Publish/get-git-tag-name';
 
 const pkg = { name: 'megapkg', version: '1.0.0' };
-const gitTagName = `${pkg.name}@${pkg.version}-gitpkg`;
+const gitTagName = `${pkg.name}-v${pkg.version}-gitpkg`;
 
 describe('while using getGitTagName()', () => {
   it(`should return "${gitTagName}"`, () => {


### PR DESCRIPTION
npm5 has issues with git tags with @ and / chars.

NOTE: this doesn't happen with npm 3