### PR TITLE
Fix aimed at #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitpkg",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Publish packages as git tags",
   "main": "build/index.js",
   "scripts": {

--- a/src/tasks/Publish/get-git-tag-latest.js
+++ b/src/tasks/Publish/get-git-tag-latest.js
@@ -1,0 +1,6 @@
+import { normalisePackageNameNpm } from './normalise-package-name';
+
+export default function getGitTagLatest(pkg) {
+  const gitpkgPackageName = `${normalisePackageNameNpm(pkg.name)}-latest`;
+  return gitpkgPackageName;
+}

--- a/src/tasks/Publish/upload-package.js
+++ b/src/tasks/Publish/upload-package.js
@@ -25,6 +25,14 @@ export default async function uploadPackage(pkg, pkgPath, registry) {
     throw err;
   }
   // move 'latest' tag for module ${gitTagLatest} to current setting
-  await execLikeShell(`git push --delete origin ${gitTagLatest}`, pkgTempDirPkg);
-  await execLikeShell(`git push tag origin ${gitTagLatest}`, pkgTempDirPkg);
+  try {
+    await execLikeShell(`git push --delete origin ${gitTagLatest}`, pkgTempDirPkg);
+  } catch (err) {
+    const msg = /unable to delete '.*': remote ref does not exist/;
+    if (!err.stderr.match(msg)) {
+      throw err; // unknown error, bubble up
+    }
+  }
+  await execLikeShell(`git tag ${gitTagLatest}`, pkgTempDirPkg);
+  await execLikeShell(`git push --tags`, pkgTempDirPkg);
 }

--- a/src/tasks/Publish/upload-package.js
+++ b/src/tasks/Publish/upload-package.js
@@ -2,11 +2,13 @@ import path from 'path';
 import execLikeShell from './exec-like-shell';
 import getTempDir from './get-temp-dir';
 import getGitTagName from './get-git-tag-name';
+import getGitTagLatest from './get-git-tag-latest';
 
 export default async function uploadPackage(pkg, pkgPath, registry) {
   const pkgTempDir = await getTempDir(pkg);
   const pkgTempDirPkg = path.join(pkgTempDir, 'package');
   const gitpkgPackageName = getGitTagName(pkg);
+  const gitTagLatest = getGitTagLatest(pkg);
   await execLikeShell('git init', pkgTempDirPkg);
   await execLikeShell('git add .', pkgTempDirPkg);
   await execLikeShell('git commit -m gitpkg', pkgTempDirPkg);
@@ -20,7 +22,9 @@ export default async function uploadPackage(pkg, pkgPath, registry) {
     if (exists) {
       throw new Error(`The git tag "${gitpkgPackageName}" already exists in "${registry}".`);
     }
-
     throw err;
   }
+  // move 'latest' tag for module ${gitTagLatest} to current setting
+  await execLikeShell(`git push --delete origin ${gitTagLatest}`, pkgTempDirPkg);
+  await execLikeShell(`git push tag origin ${gitTagLatest}`, pkgTempDirPkg);
 }

--- a/test/tasks/get-git-tag-latest.test.js
+++ b/test/tasks/get-git-tag-latest.test.js
@@ -1,0 +1,10 @@
+import getGitTagLatest from '../../src/tasks/Publish/get-git-tag-latest';
+
+const pkg = { name: 'megapkg', version: '1.0.0' };
+const gitTagLatest = `${pkg.name}-latest`;
+
+describe('while using getGitTagLatest()', () => {
+  it(`should return "${gitTagLatest}"`, () => {
+    expect(getGitTagLatest(pkg)).toBe(gitTagLatest);
+  });
+});


### PR DESCRIPTION
fixes #9 
Tags created:
Before: `${pkgName}-v${pkg.version}-gitpkg`
After: `${pkgName}-v${pkg.version}-gitpkg` & `${pkgName}-latest`