### PR TITLE
 Bypass git hooks by default

### DIFF
--- a/src/tasks/Publish/upload-package.js
+++ b/src/tasks/Publish/upload-package.js
@@ -1,22 +1,22 @@
-import path from "path";
-import execLikeShell from "./exec-like-shell";
-import getTempDir from "./get-temp-dir";
-import getGitTagName from "./get-git-tag-name";
+import path from 'path';
+import execLikeShell from './exec-like-shell';
+import getTempDir from './get-temp-dir';
+import getGitTagName from './get-git-tag-name';
 
 export default async function uploadPackage(config, pkg, registry) {
   const pkgTempDir = await getTempDir(pkg);
-  const pkgTempDirPkg = path.join(pkgTempDir, "package");
+  const pkgTempDirPkg = path.join(pkgTempDir, 'package');
   const gitpkgPackageName = getGitTagName(pkg, config);
-  await execLikeShell("git init", pkgTempDirPkg);
-  await execLikeShell("git add .", pkgTempDirPkg);
-  await execLikeShell("git commit --no-verify -m gitpkg", pkgTempDirPkg);
+  await execLikeShell('git init', pkgTempDirPkg);
+  await execLikeShell('git add .', pkgTempDirPkg);
+  await execLikeShell('git commit --no-verify -m gitpkg', pkgTempDirPkg);
   await execLikeShell(`git remote add origin ${registry}`, pkgTempDirPkg);
   await execLikeShell(`git tag ${gitpkgPackageName}`, pkgTempDirPkg);
   try {
     await execLikeShell(`git push origin ${gitpkgPackageName}`, pkgTempDirPkg);
   } catch (err) {
     const gitErrorExists =
-      "Updates were rejected because the tag already exists in the remote.";
+      'Updates were rejected because the tag already exists in the remote.';
     const exists = err.stderr.indexOf(gitErrorExists) > -1;
     if (exists) {
       throw new Error(

--- a/src/tasks/Publish/upload-package.js
+++ b/src/tasks/Publish/upload-package.js
@@ -1,24 +1,27 @@
-import path from 'path';
-import execLikeShell from './exec-like-shell';
-import getTempDir from './get-temp-dir';
-import getGitTagName from './get-git-tag-name';
+import path from "path";
+import execLikeShell from "./exec-like-shell";
+import getTempDir from "./get-temp-dir";
+import getGitTagName from "./get-git-tag-name";
 
 export default async function uploadPackage(config, pkg, registry) {
   const pkgTempDir = await getTempDir(pkg);
-  const pkgTempDirPkg = path.join(pkgTempDir, 'package');
+  const pkgTempDirPkg = path.join(pkgTempDir, "package");
   const gitpkgPackageName = getGitTagName(pkg, config);
-  await execLikeShell('git init', pkgTempDirPkg);
-  await execLikeShell('git add .', pkgTempDirPkg);
-  await execLikeShell('git commit -m gitpkg', pkgTempDirPkg);
+  await execLikeShell("git init", pkgTempDirPkg);
+  await execLikeShell("git add .", pkgTempDirPkg);
+  await execLikeShell("git commit --no-verify -m gitpkg", pkgTempDirPkg);
   await execLikeShell(`git remote add origin ${registry}`, pkgTempDirPkg);
   await execLikeShell(`git tag ${gitpkgPackageName}`, pkgTempDirPkg);
   try {
     await execLikeShell(`git push origin ${gitpkgPackageName}`, pkgTempDirPkg);
   } catch (err) {
-    const gitErrorExists = 'Updates were rejected because the tag already exists in the remote.';
+    const gitErrorExists =
+      "Updates were rejected because the tag already exists in the remote.";
     const exists = err.stderr.indexOf(gitErrorExists) > -1;
     if (exists) {
-      throw new Error(`The git tag "${gitpkgPackageName}" already exists in "${registry}".`);
+      throw new Error(
+        `The git tag "${gitpkgPackageName}" already exists in "${registry}".`
+      );
     }
 
     throw err;


### PR DESCRIPTION
`npm publish` doesn't run git hooks, gitpkg shouldn't either