### PR TITLE
fix: support yarn berry

### DIFF
--- a/src/tasks/Publish/get-npm-client.js
+++ b/src/tasks/Publish/get-npm-client.js
@@ -1,24 +1,8 @@
-import execa from 'execa';
-
-let cacheNpmClient = null;
+import getYarnLineage from './get-yarn-lineage';
 
 export default async function getNpmClient() {
-  if (cacheNpmClient) {
-    return cacheNpmClient;
-  }
-
-  const useYarn = await shouldUseYarn();
-  const npmClient = useYarn ? 'yarn' : 'npm';
-  cacheNpmClient = npmClient;
+  const yarnLineage = await getYarnLineage();
+  const npmClient = yarnLineage === null ? 'npm' : 'yarn';
 
   return npmClient;
-}
-
-async function shouldUseYarn() {
-  try {
-    await execa('yarn', ['--version']);
-    return true;
-  } catch (e) {
-    return false;
-  }
 }

--- a/src/tasks/Publish/get-tarball-name.js
+++ b/src/tasks/Publish/get-tarball-name.js
@@ -1,15 +1,20 @@
 import getNpmClient from './get-npm-client';
+import getYarnLineage from './get-yarn-lineage';
 import normalisePackageName from './normalise-package-name';
 
 export default async function getTarballName(pkg) {
   const npmClient = await getNpmClient();
+  const yarnLineage = await getYarnLineage();
   const packageName = await normalisePackageName(pkg.name);
 
   if (npmClient === 'npm') {
     const filename = `${packageName}-${pkg.version}.tgz`;
     return filename;
+  } else if (yarnLineage === 'classic') {
+    const filename = `${packageName}-v${pkg.version}.tgz`;
+    return filename;
   }
 
-  const filename = `${packageName}-v${pkg.version}.tgz`;
+  const filename = `package.tgz`;
   return filename;
 }

--- a/src/tasks/Publish/get-yarn-lineage.js
+++ b/src/tasks/Publish/get-yarn-lineage.js
@@ -1,0 +1,24 @@
+import execa from 'execa';
+
+let yarnLineage = undefined;
+
+export default async function getYarnLineage() {
+  if (yarnLineage !== undefined) {
+    return yarnLineage;
+  }
+
+  try {
+    const {stdout} = await execa('yarn', ['--version']);
+    yarnLineage = parseInt(stdout) > 1
+      ? 'berry'
+      : 'classic';
+  } catch (e) {
+    yarnLineage = null;
+  }
+
+  return yarnLineage;
+}
+
+export function setYarnLineageForTesting(value) {
+  yarnLineage = value;
+}

--- a/test/tasks/get-npm-client.test.js
+++ b/test/tasks/get-npm-client.test.js
@@ -1,63 +1,27 @@
-describe('while calling getNpmClient() with only npm client installed', () => {
+describe('while calling getNpmClient()', () => {
   let getNpmClient = null;
-  let mockFn = null;
+  let setYarnLineageForTesting = null;
 
   beforeAll(async () => {
     getNpmClient = (await import('../../src/tasks/Publish/get-npm-client')).default;
-    mockFn = await import('execa');
-    jest.mock('execa');
+    setYarnLineageForTesting = (await import('../../src/tasks/Publish/get-yarn-lineage')).setYarnLineageForTesting;
   });
 
-  beforeEach(() => {
-    mockFn.mockReset();
-    mockFn.mockImplementation(() => Promise.reject());
-  });
-
-  afterAll(() => {
-    jest.unmock('execa');
-  });
-
-  it('should return "npm"', async () => {
+  it('should return "npm" when yarn is not installed', async () => {
+    setYarnLineageForTesting(null);
     const npmClient = await getNpmClient();
-    expect(mockFn.mock.calls.length).toEqual(1);
     expect(npmClient).toBe('npm');
   });
 
-  it('should return "npm" from cache without running any command with "execa"', async () => {
+  it('should return "yarn" when yarn classic is being used', async () => {
+    setYarnLineageForTesting('classic');
     const npmClient = await getNpmClient();
-    expect(mockFn.mock.calls.length).toEqual(0);
-    expect(npmClient).toBe('npm');
-  });
-});
-
-describe('while calling getNpmClient() with yarn client installed', () => {
-  let getNpmClient = null;
-  let mockFn = null;
-  beforeAll(async () => {
-    jest.resetModules();
-    getNpmClient = (await import('../../src/tasks/Publish/get-npm-client')).default;
-    mockFn = await import('execa');
-    jest.mock('execa');
-  });
-
-  beforeEach(() => {
-    mockFn.mockReset();
-    mockFn.mockImplementation(() => Promise.resolve());
-  });
-
-  afterAll(() => {
-    jest.unmock('execa');
-  });
-
-  it('should return "yarn"', async () => {
-    const npmClient = await getNpmClient();
-    expect(mockFn.mock.calls.length).toEqual(1);
     expect(npmClient).toBe('yarn');
   });
 
-  it('should return "yarn" from cache without running any command with "execa"', async () => {
+  it('should return "yarn" when yarn berry is being used', async () => {
+    setYarnLineageForTesting('berry');
     const npmClient = await getNpmClient();
-    expect(mockFn.mock.calls.length).toEqual(0);
     expect(npmClient).toBe('yarn');
   });
 });

--- a/test/tasks/get-yarn-lineage.test.js
+++ b/test/tasks/get-yarn-lineage.test.js
@@ -1,0 +1,95 @@
+describe('while calling getYarnLineage() with only npm client installed', () => {
+  let getYarnLineage = null;
+  let mockFn = null;
+
+  beforeAll(async () => {
+    getYarnLineage = (await import('../../src/tasks/Publish/get-yarn-lineage')).default;
+    mockFn = await import('execa');
+    jest.mock('execa');
+  });
+
+  beforeEach(() => {
+    mockFn.mockReset();
+    mockFn.mockImplementation(() => Promise.reject());
+  });
+
+  afterAll(() => {
+    jest.unmock('execa');
+  });
+
+  it('should return null', async () => {
+    const yarnLineage = await getYarnLineage();
+    expect(mockFn.mock.calls.length).toEqual(1);
+    expect(yarnLineage).toBe(null);
+  });
+
+  it('should return null from cache without running any command with "execa"', async () => {
+    const yarnLineage = await getYarnLineage();
+    expect(mockFn.mock.calls.length).toEqual(0);
+    expect(yarnLineage).toBe(null);
+  });
+});
+
+describe('while calling getYarnLineage() with yarn classic client installed', () => {
+  let getYarnLineage = null;
+  let mockFn = null;
+  beforeAll(async () => {
+    jest.resetModules();
+    getYarnLineage = (await import('../../src/tasks/Publish/get-yarn-lineage')).default;
+    mockFn = await import('execa');
+    jest.mock('execa');
+  });
+
+  beforeEach(() => {
+    mockFn.mockReset();
+    mockFn.mockImplementation(() => Promise.resolve({stdout: '1.22.17'}));
+  });
+
+  afterAll(() => {
+    jest.unmock('execa');
+  });
+
+  it('should return "classic"', async () => {
+    const yarnLineage = await getYarnLineage();
+    expect(mockFn.mock.calls.length).toEqual(1);
+    expect(yarnLineage).toBe('classic');
+  });
+
+  it('should return "classic" from cache without running any command with "execa"', async () => {
+    const yarnLineage = await getYarnLineage();
+    expect(mockFn.mock.calls.length).toEqual(0);
+    expect(yarnLineage).toBe('classic');
+  });
+});
+
+describe('while calling getYarnLineage() with yarn berry client installed', () => {
+  let getYarnLineage = null;
+  let mockFn = null;
+  beforeAll(async () => {
+    jest.resetModules();
+    getYarnLineage = (await import('../../src/tasks/Publish/get-yarn-lineage')).default;
+    mockFn = await import('execa');
+    jest.mock('execa');
+  });
+
+  beforeEach(() => {
+    mockFn.mockReset();
+    mockFn.mockImplementation(() => Promise.resolve({stdout: '3.2.1'}));
+  });
+
+  afterAll(() => {
+    jest.unmock('execa');
+  });
+
+  it('should return "berry"', async () => {
+    const yarnLineage = await getYarnLineage();
+    expect(mockFn.mock.calls.length).toEqual(1);
+    expect(yarnLineage).toBe('berry');
+  });
+
+  it('should return "berry" from cache without running any command with "execa"', async () => {
+    const yarnLineage = await getYarnLineage();
+    expect(mockFn.mock.calls.length).toEqual(0);
+    expect(yarnLineage).toBe('berry');
+  });
+});


### PR DESCRIPTION
Adding support for the default package name in Berry (`package.tgz`) is the simplest fix.

Alternatively, we could detect the yarn lineage and use `--filename` (classic) or `--out` (berry) to use the same package name across clients.

Fixes #43

---

I haven't used jest before, so getting the tests to work has been a chore.  I was able to adapt your `get-npm-client` test to work for `get-yarn-lineage`, but I don't know the right way to mock a local module to update the `get-npm-client` test.